### PR TITLE
ISSUE #2: Adds TOPICS configuration to textfile

### DIFF
--- a/index_twitter_stream.py
+++ b/index_twitter_stream.py
@@ -18,7 +18,13 @@ from esconn import esconn
 es = esconn()
 
 # Update with topics to follow
-TOPICS = ["breitbart", "cucks"]
+if sys.argv[1]:
+    f = open(sys.argv[1])
+else:
+    f = open('topics.txt')
+    
+topics = f.readlines()
+TOPICS = [topic.replace('\n', '').strip() for topic in topics]
 
 
 class StreamListener(tweepy.StreamListener):
@@ -26,7 +32,7 @@ class StreamListener(tweepy.StreamListener):
         super(StreamListener, self).__init__()
         self.counter = 0
         self.limit = 500
-        
+
     def on_status(self, status):
         if self.counter < self.limit:
             description = status.user.description

--- a/topics.txt
+++ b/topics.txt
@@ -1,0 +1,2 @@
+cucks
+breitbart


### PR DESCRIPTION
@hadoopjax This addresses Issue #2 . I used sys.argv for simplicity, but if you would like me to import argparse and use ArgParsing on the command line we can do that instead. Another separate option would be to use config package and define the filepath in the `config.py`. Which do you think works best? I think the deciding factor is whether we prefer the flexibility of command line parsing. or the definitiveness of specifying a path in the `config.py`

Thoughts? 