### PR TITLE
Issue #22: Fix for build_status_attr.py

### DIFF
--- a/build_status_attr.py
+++ b/build_status_attr.py
@@ -1,6 +1,5 @@
 import tweepy
-from config import esconn, aws_config, twitter_config
-from elasticsearch import Elasticsearch,helpers
+from config import esconn, twitter_config
 from get_stream_output_results import getStreamResultStatusIDs
 
 # unicode mgmt
@@ -16,19 +15,15 @@ auth = tweepy.OAuthHandler(twitter_config.CONSUMER_KEY, twitter_config.CONSUMER_
 auth.set_access_token(twitter_config.ACCESS_TOKEN, twitter_config.ACCESS_TOKEN_SECRET)
 api = tweepy.API(auth)
 
-# load Twitter screen_name & build a search
-#status_id_list = getStreamResultStatusIDs()
-status_id_list = [813859926485463040, 638748404827443201]
 
-def getAttributesbyStatusID(handles):
-    for status in status_id_list:
-        search = api.statuses_lookup(status, include_entities='yes')
+def getAttributesbyStatusID(statuses):
+        search = api.statuses_lookup(statuses, include_entities='yes')
         for item in search:
-            print item.id + ' ' + item.text
+            # print str(item.id) + ': ' + item.text
+            yield item
 
-output = set()
-for status in status_id_list:
-    output.add(getAttributesbyStatusID(status_id_list))
+# load Twitter screen_name & build a search
+status_id_list = getStreamResultStatusIDs(size=10)
+output = {item for item in getAttributesbyStatusID(status_id_list)}
 
 print output
-

--- a/get_stream_output_results.py
+++ b/get_stream_output_results.py
@@ -6,14 +6,14 @@ from config import esconn
 es = esconn.esconn()
 
 def getStreamResultHandles():
-    resp = es.search(index="twitter", doc_type="message", size="100", filter_path=['hits.hits._source.name'])
+    resp = es.search(index="twitter", doc_type="tweets", size="100", filter_path=['hits.hits._source.name'])
     output = set()
     for doc in resp['hits']['hits']:
         output.add(doc['_source']['name'])
     return list(output)
 
-def getStreamResultStatusIDs():
-    resp = es.search(index="twitter", doc_type="message", size="1", filter_path=['hits.hits._source.id_str'])
+def getStreamResultStatusIDs(size):
+    resp = es.search(index="twitter", doc_type="tweets", size=size, filter_path=['hits.hits._source.id_str'])
     output = set()
     for doc in resp['hits']['hits']:
         output.add(doc['_source']['id_str'])


### PR DESCRIPTION
the `api.statuses_lookup(statuses, include_entities='yes')` takes a list rather than an individual status so the for loop was unnecessary. I did some cleanup around the `getAttributesByStatusID` and the `getStreamResultsStatusID` functions. Feel free to change at your leisure.