### PR TITLE
Add cron support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir discursive
 COPY . /discursive
 
 RUN apk add --update \
+    tini \
     python \
     py2-pip && \
     adduser -D aws
@@ -16,6 +17,7 @@ RUN mkdir aws && \
     pip install awscli && \
     pip install -q --upgrade pip && \
     pip install -q --upgrade setuptools && \
-    pip install -q -r /discursive/requirements.txt
+    pip install -q -r /discursive/requirements.txt && \
+    crontab /discursive/crontab
 
-CMD ["python", "/discursive/index_twitter_stream.py", "/discursive/topics.txt"]
+CMD ["/sbin/tini", "--", "crond", "-f"]

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+* * * * *	python /discursive/test.py arg1 arg2

--- a/test.py
+++ b/test.py
@@ -1,0 +1,10 @@
+import sys
+import logging
+import time
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s %(message)s')
+    logger = logging.getLogger()
+    logger.warn("started " + " ".join(sys.argv))
+    time.sleep(65)
+    logger.warn("stopped " + " ".join(sys.argv))


### PR DESCRIPTION
#25 

Added boilerplate to run process from cron, using tini  to
reap zombies and handle signals.

Edit crontab as appropriate to run the process you want.
test.py just logs the time.