### PR TITLE
Poll User Data daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,31 @@ Once you have cloned the repo you're ready to rock:
 
 2. Change into the Discursive directory (i.e. `cd discursive/`).
 
-3. Run `essetup.py` which is located in the `/config` directory, which'll generate the Elasticsearch index with the appropriate mappings.
+3. If not installed yet on your EC2 instance, install pip. For Ubuntu: `sudo apt-get install python2-pip`
 
-4. Update the `aws_config.py` `twitter_config.py` `esconn.py` and `s3conn.py` files located in the `/config` directory with your credentials.
+4. Install requirements by running `pip2 install -r requirements.txt`
 
-5. Put your desired keyword(s) in the `topics.txt` file (one term per line).
+5. Update the `aws_config.py` `twitter_config.py` `esconn.py` and `s3conn.py` files located in the `/config` directory with your credentials.
 
-6. Edit the `crontab` file to run at your desired intervals. The default will run every fifteen minutes. 
+6. Run `essetup.py` which is located in the `/config` directory, which'll generate the Elasticsearch index with the appropriate mappings.
 
-7. Run `sudo docker build -t discursive .`
+7. Put your desired keyword(s) in the `topics.txt` file (one term per line).
 
-8. Run `sudo docker run discursive`
+8. Edit the `crontab` file to run at your desired intervals. The default will run every fifteen minutes. 
 
-9. If all went well you're watching Tweets stream into your Elasticsearch index! Conversely, run `index_twitter_search.py` to search for specific topic(s) and bulk insert the data into your Elasticsearch index (and see the messages from Elasticsearch returned to your console).
+9. Run `sudo docker build -t discursive .`
 
-10. There are several options you may want to configure/tweak. For instance, you may want to turn off printing to console (which you can do in `index_twitter_search.py`) or run the container as a detached process. Please do jump into our Slack channel #assemble if you have any questions or log an issue!
+10. Run `sudo docker run discursive`
+
+11. If all went well you're watching Tweets stream into your Elasticsearch index! Conversely, run `index_twitter_search.py` to search for specific topic(s) and bulk insert the data into your Elasticsearch index (and see the messages from Elasticsearch returned to your console).
+
+12. There are several options you may want to configure/tweak. For instance, you may want to turn off printing to console (which you can do in `index_twitter_search.py`) or run the container as a detached process. Please do jump into our Slack channel #assemble if you have any questions or log an issue!
+
+## Configuring discursive for AWS
+
+### aws_config.py
+
+1. If you not already have done so, (create a IAM)[] user for programmatic access.
 
 ## Explore Twitter networks
 

--- a/README.md
+++ b/README.md
@@ -23,31 +23,21 @@ Once you have cloned the repo you're ready to rock:
 
 2. Change into the Discursive directory (i.e. `cd discursive/`).
 
-3. If not installed yet on your EC2 instance, install pip. For Ubuntu: `sudo apt-get install python2-pip`
+3. Run `essetup.py` which is located in the `/config` directory, which'll generate the Elasticsearch index with the appropriate mappings.
 
-4. Install requirements by running `pip2 install -r requirements.txt`
+4. Update the `aws_config.py` `twitter_config.py` `esconn.py` and `s3conn.py` files located in the `/config` directory with your credentials.
 
-5. Update the `aws_config.py` `twitter_config.py` `esconn.py` and `s3conn.py` files located in the `/config` directory with your credentials.
+5. Put your desired keyword(s) in the `topics.txt` file (one term per line).
 
-6. Run `essetup.py` which is located in the `/config` directory, which'll generate the Elasticsearch index with the appropriate mappings.
+6. Edit the `crontab` file to run at your desired intervals. The default will run every fifteen minutes. 
 
-7. Put your desired keyword(s) in the `topics.txt` file (one term per line).
+7. Run `sudo docker build -t discursive .`
 
-8. Edit the `crontab` file to run at your desired intervals. The default will run every fifteen minutes. 
+8. Run `sudo docker run discursive`
 
-9. Run `sudo docker build -t discursive .`
+9. If all went well you're watching Tweets stream into your Elasticsearch index! Conversely, run `index_twitter_search.py` to search for specific topic(s) and bulk insert the data into your Elasticsearch index (and see the messages from Elasticsearch returned to your console).
 
-10. Run `sudo docker run discursive`
-
-11. If all went well you're watching Tweets stream into your Elasticsearch index! Conversely, run `index_twitter_search.py` to search for specific topic(s) and bulk insert the data into your Elasticsearch index (and see the messages from Elasticsearch returned to your console).
-
-12. There are several options you may want to configure/tweak. For instance, you may want to turn off printing to console (which you can do in `index_twitter_search.py`) or run the container as a detached process. Please do jump into our Slack channel #assemble if you have any questions or log an issue!
-
-## Configuring discursive for AWS
-
-### aws_config.py
-
-1. If you not already have done so, (create a IAM)[] user for programmatic access.
+10. There are several options you may want to configure/tweak. For instance, you may want to turn off printing to console (which you can do in `index_twitter_search.py`) or run the container as a detached process. Please do jump into our Slack channel #assemble if you have any questions or log an issue!
 
 ## Explore Twitter networks
 

--- a/config/essetup.py
+++ b/config/essetup.py
@@ -44,7 +44,7 @@ settings = {
             'friends_count': {'type': 'long'},
             'location': {'type': 'string'},
             'description': {'type': 'string'},
-            'favorites_count': {'type': 'long'},
+            'favourites_count': {'type': 'long'},
             'statuses_count': {'type': 'long'},
             'listed_count': {'type': 'long'},
             'profile_background_image_url': {'type': 'string'},

--- a/config/essetup.py
+++ b/config/essetup.py
@@ -35,6 +35,20 @@ settings = {
                 'original_id': {'type': 'string'},
                 'original_name': {'type': 'string'}
             }
+        },
+        'users': {
+            'id': {'type': 'long'},
+            'name': {'type': 'string'},
+            'screen_name': {'type': 'string'},
+            'followers_count': {'type': 'long'},
+            'friends_count': {'type': 'long'},
+            'location': {'type': 'string'},
+            'description': {'type': 'string'},
+            'favorites_count': {'type': 'long'},
+            'statuses_count': {'type': 'long'},
+            'listed_count': {'type': 'long'},
+            'profile_background_image_url': {'type': 'string'},
+            'profile_image_url': {'type': 'string'}
         }
     }
 }

--- a/crontab
+++ b/crontab
@@ -1,1 +1,2 @@
 0,15,30,45 * * * * python /discursive/index_twitter_stream.py /discursive/topics.txt
+0 * * * * python /discursive/index_user_profiles.py /discursive/users.txt

--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
 0,15,30,45 * * * * python /discursive/index_twitter_stream.py /discursive/topics.txt
-0 * * * * python /discursive/index_user_profiles.py /discursive/users.txt
+0 0 * * * python /discursive/index_user_profiles.py /discursive/users.txt

--- a/index_user_profiles.py
+++ b/index_user_profiles.py
@@ -35,7 +35,7 @@ else:
         sys.exit('ERROR: Default users.txt not found. No alternate topic file  was provided')
 
 
-USERS = [user.replace('\n', '').strip().replace('@', '') for user in users]
+USERS = [user.replace('\n', '').strip() for user in users]
 
 def retrieve_user_data():
     try:
@@ -69,7 +69,8 @@ def get_time_stamp():
 def get_twitter_users_pipeline():
     time_stamp = get_time_stamp()
     user_data = retrieve_user_data()
-    mapped_user_data = map_user_for_es(user_data, time_stamp)
-    dump_to_elastic(mapped_user_data)
+    for user in user_data:
+        mapped_user_data = map_user_for_es(user_data, time_stamp)
+        dump_to_elastic(mapped_user_data)
 
 get_twitter_users_pipeline()

--- a/index_user_profiles.py
+++ b/index_user_profiles.py
@@ -1,0 +1,75 @@
+import json
+import tweepy
+from config import esconn, aws_config, twitter_config
+import os
+from datetime import datetime as dt
+from config import s3conn
+
+# unicode mgmt
+import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
+
+# Twitter auth and api call setup
+auth = tweepy.OAuthHandler(twitter_config.CONSUMER_KEY, twitter_config.CONSUMER_SECRET)
+auth.set_access_token(twitter_config.ACCESS_TOKEN, twitter_config.ACCESS_TOKEN_SECRET)
+api = tweepy.API(auth)
+
+# Get elasticsearch connection
+es = esconn.esconn()
+
+if len(sys.argv) > 2:
+    sys.exit('ERROR: Received 2 or more arguments: {} {} {} Expected 1: User file name'.format(sys.argv[0], sys.argv[1], sys.argv[2]))
+
+elif len(sys.argv) == 2:
+    try:
+        with open(sys.argv[1]) as f:
+            users = f.readlines()
+    except Exception:
+        sys.exit('ERROR: Expected user file %s not found' % sys.argv[1])
+else:
+    try:
+        with open('users.txt') as f:
+            users = f.readlines()
+    except:
+        sys.exit('ERROR: Default users.txt not found. No alternate topic file  was provided')
+
+
+USERS = [user.replace('\n', '').strip().replace('@', '') for user in users]
+
+def retrieve_user_data():
+    try:
+        return api.lookup_users(user_ids=USERS)
+    except tweepy.TweepError as e:
+        sys.exit("An error occured looking up the user_ids. Verify the correctness and existance of the given screen names, handles or ids.")
+
+def map_user_for_es(user, time_stamp):
+    return {
+        'timestamp': time_stamp,
+        'id': user.id,
+        'name': user.screen_name,
+        'screen_name': user.screen_name,
+        'followers_count': user.followers_count,
+        'friends_count': user.friends_count,
+        'location': user.location,
+        'description': user.description,
+        'favorites_count': user.favorites_count,
+        'statuses_count': user.statuses_count,
+        'listed_count': user.listed_count,
+        'profile_background_image_url': user.profile_background_image_url,
+        'profile_image_url': user.profile_image_url
+    }  
+
+def dump_to_elastic(bodydata):
+    es.index(index='twitter', doc_type="users", body=bodydata)
+
+def get_time_stamp():
+    return dt.now()
+
+def get_twitter_users_pipeline():
+    time_stamp = get_time_stamp()
+    user_data = retrieve_user_data()
+    mapped_user_data = map_user_for_es(user_data, time_stamp)
+    dump_to_elastic(mapped_user_data)
+
+get_twitter_users_pipeline()

--- a/index_user_profiles.py
+++ b/index_user_profiles.py
@@ -53,7 +53,7 @@ def map_user_for_es(user, time_stamp):
         'friends_count': user.friends_count,
         'location': user.location,
         'description': user.description,
-        'favorites_count': user.favorites_count,
+        'favourites_count': user.favourites_count,
         'statuses_count': user.statuses_count,
         'listed_count': user.listed_count,
         'profile_background_image_url': user.profile_background_image_url,
@@ -70,7 +70,7 @@ def get_twitter_users_pipeline():
     time_stamp = get_time_stamp()
     user_data = retrieve_user_data()
     for user in user_data:
-        mapped_user_data = map_user_for_es(user_data, time_stamp)
+        mapped_user_data = map_user_for_es(user, time_stamp)
         dump_to_elastic(mapped_user_data)
 
 get_twitter_users_pipeline()

--- a/users.txt
+++ b/users.txt
@@ -1,0 +1,2 @@
+@realDonaldTrump
+@Google

--- a/users.txt
+++ b/users.txt
@@ -1,2 +1,2 @@
-@realDonaldTrump
-@Google
+25073877
+20536157


### PR DESCRIPTION
Implementing a daily poll of twitter user data as described in issue #16.

Running the docker instance now will next indexing tweets with specified topics also fetch user data once a day. 
The timing is achieved by extending the original `crontab`-script.
The `index_user_profiles.py`-script takes a file listing the user-IDs of the user data to be pulled separated by line breaks. It uses the `lookup_users()` method of tweepy to fetch the data from Twitter's REST API and hands it to ElasticSearch for indexing.

The following features are extracted from the full set of user features provided by the twitter API:

- 'timestamp'
- 'id'
- 'name'
- 'screen_name'
- 'followers_count'
- 'friends_count'
- 'location'
- 'description'
- 'favourites_count'
- 'statuses_count'
- 'listed_count'
- 'profile_background_image_url'
- 'profile_image_url'

If you have further suggestions or found bugs, I would be happy to deal with those as well.

Cheers,
Thomas